### PR TITLE
Create basic autocomplete with example code

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -1,24 +1,84 @@
 import React from 'react';
-import { StyleSheet, Text, TextInput, View } from 'react-native';
+import {
+  FlatList,
+  Text,
+  TextInput, TouchableOpacity,
+  View
+} from 'react-native';
+
 import AutocompleteJar from 'react-native-autocomplete-jar';
+import { styles } from './styles';
+import * as fakeApi from './fakeApi';
 
 export default class App extends React.Component {
+  _renderItem = ({ item }) => (
+    <TouchableOpacity
+      onPress={() => { console.log(item.id) }}
+      style={styles.item}
+    >
+      <Text style={styles.itemText}>
+        { item.text }
+      </Text>
+    </TouchableOpacity>
+  )
+
+  _renderSeparator = () => (<View style={styles.separator} />);
+
+  _keyExtractor = ({ id }) => id
+
+  _renderAutocomplete = ({ onChangeText, value, result }) => {
+    const { status, data, error } = result;
+
+    return (
+      <View>
+        <TextInput
+          onChangeText={onChangeText}
+          value={value}
+          placeholder="Type something!"
+          returnKeyType="done"
+          style={styles.textInput}
+        />
+        { status === 'LOADING' ? (
+          <View style={styles.item}>
+            <Text style={styles.itemTextMuted}>Searching...</Text>
+          </View>
+        ) : status === 'ERROR' ? (
+          <View style={styles.item}>
+            <Text style={styles.itemTextError}>
+              There was a problem getting your results
+            </Text>
+          </View>
+        ) : status === 'SUCCESS' && !data.length ? (
+          <View style={styles.autocompleteInfo}>
+            <Text style={styles.itemTextMuted}>
+              No results could be found. { error.message }
+            </Text>
+          </View>
+        ) : status === 'SUCCESS' ? (
+          <FlatList
+            data={data}
+            keyExtractor={this._keyExtractor}
+            renderItem={this._renderItem}
+            ItemSeparatorComponent={this._renderSeparator}
+            // Needed, otherwise the user will need to tap the item twice
+            // for the onPress to call
+            keyboardShouldPersistTaps="handled"
+          />
+        ) : null
+        }
+      </View>
+    );
+  }
+
   render() {
     return (
       <View style={styles.root}>
         <Text style={styles.heading}>Autocomplete Example</Text>
-        <AutocompleteJar />
+
+        <AutocompleteJar fetchResults={fakeApi.fetchResults}>
+          {this._renderAutocomplete}
+        </AutocompleteJar>
       </View>
     );
   }
 }
-
-const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    margin: 20,
-  },
-  heading: {
-    fontWeight: 'bold',
-  },
-});

--- a/examples/fakeApi.js
+++ b/examples/fakeApi.js
@@ -1,0 +1,14 @@
+export const fetchResults = (query) => new Promise((resolve, reject) => {
+  setTimeout(() => {
+    resolve([{
+      text: `${query} - 1`,
+      id: '1',
+    }, {
+      text: `${query} - 2`,
+      id: '2',
+    }, {
+      text: `${query} - 3`,
+      id: '3',
+    }]);
+  }, 500);
+});

--- a/examples/styles.js
+++ b/examples/styles.js
@@ -1,0 +1,31 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    margin: 20,
+  },
+  heading: {
+    fontWeight: 'bold',
+  },
+  autocompleteInfo: {
+    padding: 10,
+  },
+  itemText: {
+    color: '#111111',
+  },
+  itemTextMuted: {
+    color: '#888888',
+  },
+  itemTextError: {
+    color: '#ff1719',
+  },
+  separator: {
+    height: 1,
+    width: '100%',
+    backgroundColor: '#444444',
+  },
+  textInput: {
+    height: 40,
+  },
+});

--- a/src/AutocompleteJar.js
+++ b/src/AutocompleteJar.js
@@ -1,14 +1,86 @@
 import React, { PureComponent } from 'react';
-import { View, TextInput, Text } from 'react-native';
 
-type Props = {};
+type Props = {
+  children: ({
+    onChangeText: (text) => void,
+    value: string,
+    clearText: () => void,
+    data: [any],
+  }) => React.Component,
+};
+
+const empty = { status: 'EMPTY' };
 
 export default class AutocompleteJar extends PureComponent<Props> {
+  state = {
+    results: {},
+    value: '',
+  }
+
+  componentWillUnmount() {
+    this._isUnmounted = true;
+  }
+
+  _isUnmounted = false
+
+  _onChangeText = (text) => {
+    this.setState({
+      value: text,
+    });
+    const resultData = this.state.results[text];
+    if (text && (!resultData || typeof resultData === 'string')) {
+      this.setState({
+        results: {
+          ...this.state.results,
+          [text]: { status: 'LOADING' },
+        },
+      });
+
+      const { fetchResults } = this.props;
+      fetchResults(text)
+        .then((data) => {
+          if (this._isUnmounted) return;
+
+          this.setState({
+            results: {
+              ...this.state.results,
+              [text]: { status: 'SUCCESS', data },
+            },
+          });
+
+          const { onResultsFetched } = this.props;
+          if (onResultsFetched) {
+            onResultsFetched(data);
+          }
+        })
+        .catch(error => {
+          this.setState({
+            results: {
+              ...this.state.results,
+              [text]: { status: 'ERROR', error },
+            },
+          });
+        });
+    }
+  }
+
+  _handleClearText = () => {
+    this.setState({
+      value: '',
+    });
+  }
+
   render() {
-    return (
-      <View style={{ flex: 1 }}>
-        <Text>Hello World</Text>
-      </View>
-    );
+    const { children } = this.props;
+    const { value } = this.state;
+
+    const result = this.state.results[value] || empty;
+
+    return children({
+      onChangeText: this._onChangeText,
+      value,
+      clearText: this._handleClearText,
+      result,
+    });
   }
 }


### PR DESCRIPTION
* Create basic autocomplete with example code. You'll notice that the consumer of the `AutocompleteJar` component needs to provide the render method themselves. This is intentional. Everyone that would use this component is going to want to style it to their own branding. I didn't want to provide a confusing api with a bunch of style options, and I didn't want to make the api too limiting. What a developer would do is copy/past the example react component to their project, and then they can change the render code however they like.